### PR TITLE
refactor(index.js): Changed the module exports

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,17 +9,21 @@ import 'srcdoc-polyfill';
 import '../styles/clsp-player.scss';
 
 import IovCollection from './iov/IovCollection';
+import Iov from './iov/Iov';
 import TourController from './iov/TourController';
 import utils from './utils/utils';
 
 window.IovCollection = IovCollection;
 window.TourController = TourController;
+const ClspUtils = utils;
 
 if (!window.clspUtils) {
   window.clspUtils = utils;
 }
 
-export default {
+export {
+  Iov,
   IovCollection,
   TourController,
+  ClspUtils,
 };


### PR DESCRIPTION
Changed the module export from index.js file.

This way, the consumer projects can import data from the clsp-player.min.js file, and use the classes in a simple way:

```typescript
import { IovCollection } from '@skylineos/clsp-player';

export class Test {

    constructor() {
        const iovCollection = IovCollection.asSingleton();
    }

}
```

