### PR TITLE
Include babel runtime as a project dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,17 @@
+{
+	"presets": [
+		["@babel/preset-env",
+			{
+				"exclude": [
+					"@babel/plugin-transform-typeof-symbol"
+				]
+			}]
+	],
+	"plugins": [
+		"@babel/plugin-syntax-dynamic-import",
+		"@babel/plugin-proposal-object-rest-spread",
+		"@babel/plugin-transform-async-to-generator",
+		"@babel/plugin-proposal-class-properties",
+		"@babel/plugin-transform-runtime"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -29,13 +29,18 @@
     "lodash": "4.17.15",
     "paho-mqtt": "1.1.0",
     "srcdoc-polyfill": "1.0.0",
-    "uuid": "7.0.3"
+    "uuid": "7.0.3",
+    "@babel/runtime": "^7.9.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
     "@babel/core": "7.9.0",
+    "@babel/node": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "7.9.0",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
+    "@babel/plugin-transform-async-to-generator": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/polyfill": "7.8.7",
     "@babel/preset-env": "7.9.0",
     "babel-eslint": "10.1.0",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,28 +43,15 @@ function generateConfig (name, entry) {
     output: {
       path: outputPath,
       filename: '[name].js',
+      libraryTarget: 'umd',
     },
     module: {
       rules: [
         {
-          test: /\.js$/,
-          loader: 'babel-loader?cacheDirectory=true',
-          options: {
-            presets: [
-              [
-                '@babel/preset-env',
-                {
-                  exclude: [
-                    '@babel/plugin-transform-typeof-symbol',
-                  ],
-                },
-              ],
-            ],
-            plugins: [
-              '@babel/plugin-syntax-dynamic-import',
-              '@babel/plugin-proposal-object-rest-spread',
-              '@babel/plugin-proposal-class-properties',
-            ],
+          test: /\.m?js$/,
+          exclude: /(node_modules|bower_components)/,
+          use: {
+            loader: 'babel-loader',
           },
           // @see - https://github.com/webpack/webpack/issues/2031
           include: [


### PR DESCRIPTION
Babel runtime is now a project dependency. 

With this configuration, the consumer projects can use the @skylineos/clsp-player package without adding extra dependencies to their projects. 