### PR TITLE
Feature/stry0057502

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ npm i @skylineos/clsp-player
 
 NOTE: See `demos/simple-dist/` and `demos/advanced-dist/` for full examples.
 
+A `CLSP` object is attached to `window`, which contains the classes and utils you need to create players.
+
 ### `<head>` Tag
 
 ```html
 <head>
-  <!-- CLSP Player styles -->
+  <!-- load CLSP Player styles -->
   <link
     rel="stylesheet"
     href="/path/to/dist/clsp-player.css"
@@ -115,44 +117,46 @@ NOTE: See `demos/simple-dist/` and `demos/advanced-dist/` for full examples.
 ### `<script>` Tag
 
 ```html
-<!-- CLSP Player -->
+<!-- load CLSP Player in `head` or `body` -->
 <script src="/path/to/dist/clsp-player.min.js"></script>
 
+<!-- use CLSP Player at end of `body` -->
 <script>
   var videoElementId = 'my-video';
+  var urls = [
+    'clsp://172.28.12.57:9001/FairfaxVideo0520',
+    'clsp://172.28.12.57:9001/FairfaxVideo0420',
+  ];
 
   // If you are using a Skyline SFS that uses a default CLSP stream port that
   // isn't `80` (e.g. SFS < v5.2.0), you may set the window-level default port
   // for `clsp` streams:
-  window.clspUtils.setDefaultStreamPort('clsp', 9001);
+  window.CLPS.utils.setDefaultStreamPort('clsp', 9001);
 
   // Construct the player collection
-  var clspIovCollection = window.ClspIovCollection.asSingleton();
+  var iovCollection = window.CLSP.IovCollection.asSingleton();
 
-  // Instantiate the iov instance for this video element id
-  clspIovCollection.create(videoElementId)
-    .then(function (clspIov) {
+  // Instantiate the iov instance for the target video element
+  iovCollection.create(videoElementId)
+    .then(function (iov) {
       // do something with the iov instance
-      clspIov.changeSrc('clsp://172.28.12.57:9001/FairfaxVideo0520');
+      iov.changeSrc(urls[0]);
     })
     .catch(function (error) {
       // do something with the error
+      console.error(error);
     });
 
   // Or instantiate a tour
-  var tour = window.ClspTourController.factory(
-    window.ClspIovCollection.asSingleton(),
+  var tour = window.CLSP.TourController.factory(
+    iovCollection,
     videoElementId,
     {
       intervalDuration: 10,
     },
   );
 
-  tour.addUrls([
-    'clsp://172.28.12.57:9001/FairfaxVideo0520',
-    'clsp://172.28.12.57:9001/FairfaxVideo0420',
-  ]);
-
+  tour.addUrls(urls);
   tour.start();
 </script>
 ```
@@ -191,18 +195,10 @@ NOTE: See `demos/simple-src/` and `demos/advanced-src/` for full examples.
 
 ```js
 import {
-  ClspIovCollection,
-  ClspTourController,
-  clspUtils,
+  IovCollection,
+  TourController,
+  utils,
 } from '@skylineos/clsp-player';
-
-// or ...
-
-const {
-  ClspIovCollection,
-  ClspTourController,
-  clspUtils,
-} = require('@skylineos/clsp-player');
 
 const videoElementId = 'my-video';
 const urls = [
@@ -210,32 +206,43 @@ const urls = [
   'clsp://172.28.12.57:9001/FairfaxVideo0420',
 ];
 
-// If you are using a Skyline SFS that uses a default CLSP stream port that
-// isn't `80` (e.g. SFS < v5.2.0), you may set the window-level default port
-// for `clsp` streams:
-clspUtils.setDefaultStreamPort('clsp', 9001);
+try {
+  // If you are using a Skyline SFS that uses a default CLSP stream port that
+  // isn't `80` (e.g. SFS < v5.2.0), you may set the window-level default port
+  // for `clsp` streams:
+  utils.setDefaultStreamPort('clsp', 9001);
 
-const clspIovCollection = ClspIovCollection.asSingleton();
-const clspIov = await clspIovCollection.create(videoElementId);
+  // Construct the player collection
+  const iovCollection = IovCollection.asSingleton();
 
-iov.changeSrc(urls[0]);
+  // Instantiate the iov instance for the target video element
+  const iov = await iovCollection.create(videoElementId);
 
-// tour
+  // do something with the iov instance
+  iov.changeSrc(urls[0]);
 
-const tour = ClspTourController.factory(
-  ClspIovCollection.asSingleton(),
-  videoElementId,
-  {
-    intervalDuration: 10,
-  },
-);
+  // Or instantiate a tour
+  const tour = TourController.factory(
+    iovCollection,
+    videoElementId,
+    {
+      intervalDuration: 10,
+    },
+  );
 
-tour.addUrls(urls);
-tour.start();
+  tour.addUrls(urls);
+  tour.start();
+}
+catch (error) {
+  // do something with the error
+  console.error(error);
+}
 ```
 
 ### Styles (SASS)
 
 ```scss
+@import '/path/to/node_modules/@skylineos/clsp-player/dist/clsp-player.css';
+// or import it from src
 @import '/path/to/node_modules/@skylineos/clsp-player/src/styles/clsp-player.scss';
 ```

--- a/demos/advanced-dist/index.js
+++ b/demos/advanced-dist/index.js
@@ -19,7 +19,7 @@ function destroyAllPlayers () {
 }
 
 async function createPlayer (index, playerOptions) {
-  const clspIovCollection = window.CLSP.IovCollection.asSingleton();
+  const iovCollection = window.CLSP.IovCollection.asSingleton();
 
   const videoId = `wall-video-${index}`;
 
@@ -37,7 +37,7 @@ async function createPlayer (index, playerOptions) {
 
   if (playerOptions.tour && playerOptions.tour.enabled) {
     const tour = window.CLSP.TourController.factory(
-      clspIovCollection,
+      iovCollection,
       videoElementId,
       {
         intervalDuration: 10,
@@ -70,15 +70,15 @@ async function createPlayer (index, playerOptions) {
     $container.find('.video-stream .url').text(url);
     $container.find('.video-stream .url').attr('title', url);
 
-    const clspIov = await clspIovCollection.create(videoElementId);
+    const iov = await iovCollection.create(videoElementId);
 
-    clspIov.changeSrc(url);
+    iov.changeSrc(url);
 
-    wallPlayers.push(clspIov);
+    wallPlayers.push(iov);
 
     $container.find('.video-stream .close').on('click', () => {
       $('#wallTotalVideos').text(parseInt($('#wallTotalVideos').text(), 10) - 1);
-      clspIovCollection.remove(clspIov.id);
+      iovCollection.remove(iov.id);
     });
   }
 }

--- a/demos/advanced-dist/index.js
+++ b/demos/advanced-dist/index.js
@@ -19,7 +19,7 @@ function destroyAllPlayers () {
 }
 
 async function createPlayer (index, playerOptions) {
-  const clspIovCollection = window.ClspIovCollection.asSingleton();
+  const clspIovCollection = window.CLSP.IovCollection.asSingleton();
 
   const videoId = `wall-video-${index}`;
 
@@ -36,7 +36,7 @@ async function createPlayer (index, playerOptions) {
   $container.find('.video-stream .index').text(index);
 
   if (playerOptions.tour && playerOptions.tour.enabled) {
-    const tour = window.ClspTourController.factory(
+    const tour = window.CLSP.TourController.factory(
       clspIovCollection,
       videoElementId,
       {
@@ -86,10 +86,10 @@ async function createPlayer (index, playerOptions) {
 $(() => {
   const localStorageName = 'clsp-player-advanced-demo-dist';
 
-  document.title = `v${window.clspUtils.version} ${document.title}`;
+  document.title = `v${window.CLSP.utils.version} ${document.title}`;
 
   const pageTitle = $('#page-title').html();
-  $('#page-title').html(`${pageTitle} <br /> v${window.clspUtils.version}`);
+  $('#page-title').html(`${pageTitle} <br /> v${window.CLSP.utils.version}`);
 
   initializeWall(
     localStorageName,

--- a/demos/advanced-src/index.js
+++ b/demos/advanced-src/index.js
@@ -15,7 +15,7 @@ import {
  * const {
  *   IovCollection,
  *   TourController,
- *   tils,
+ *   utils,
  * } = require('~root/dist/clsp-player.min.js');
  */
 

--- a/demos/advanced-src/index.js
+++ b/demos/advanced-src/index.js
@@ -4,18 +4,18 @@ import $ from 'jquery';
 
 // simulate `import '@skylineos/clsp-player'`
 import {
-  ClspIovCollection,
-  ClspTourController,
-  clspUtils,
+  IovCollection,
+  TourController,
+  utils,
 } from '~root/dist/clsp-player.min.js';
 
 /**
  * or with `require`....
  *
  * const {
- *   ClspIovCollection,
- *   ClspTourController,
- *   clspUtils,
+ *   IovCollection,
+ *   TourController,
+ *   tils,
  * } = require('~root/dist/clsp-player.min.js');
  */
 
@@ -36,7 +36,7 @@ function destroyAllPlayers () {
 }
 
 async function createPlayer (index, playerOptions) {
-  const clspIovCollection = ClspIovCollection.asSingleton();
+  const iovCollection = IovCollection.asSingleton();
 
   const videoId = `wall-video-${index}`;
 
@@ -53,8 +53,8 @@ async function createPlayer (index, playerOptions) {
   $container.find('.video-stream .index').text(index);
 
   if (playerOptions.tour && playerOptions.tour.enabled) {
-    const tour = ClspTourController.factory(
-      clspIovCollection,
+    const tour = TourController.factory(
+      iovCollection,
       videoElementId,
       {
         intervalDuration: 10,
@@ -87,15 +87,15 @@ async function createPlayer (index, playerOptions) {
     $container.find('.video-stream .url').text(url);
     $container.find('.video-stream .url').attr('title', url);
 
-    const clspIov = await clspIovCollection.create(videoElementId);
+    const iov = await iovCollection.create(videoElementId);
 
-    clspIov.changeSrc(url);
+    iov.changeSrc(url);
 
-    wallPlayers.push(clspIov);
+    wallPlayers.push(iov);
 
     $container.find('.video-stream .close').on('click', () => {
       $('#wallTotalVideos').text(parseInt($('#wallTotalVideos').text(), 10) - 1);
-      clspIovCollection.remove(clspIov.id);
+      iovCollection.remove(iov.id);
     });
   }
 }
@@ -103,10 +103,10 @@ async function createPlayer (index, playerOptions) {
 $(() => {
   const localStorageName = 'clsp-player-advanced-demo-src';
 
-  document.title = `v${clspUtils.version} ${document.title}`;
+  document.title = `v${utils.version} ${document.title}`;
 
   const pageTitle = $('#page-title').html();
-  $('#page-title').html(`${pageTitle} <br /> v${clspUtils.version}`);
+  $('#page-title').html(`${pageTitle} <br /> v${utils.version}`);
 
   initializeWall(
     localStorageName,

--- a/demos/advanced-src/styles.scss
+++ b/demos/advanced-src/styles.scss
@@ -1,4 +1,8 @@
-// using relative path with parent directories here to allow this file to be
+// Using relative path with parent directories here to allow this file to be
 // importable from a parent node project (e.g. @skylineos/videojs-clsp)
-@import '../../src/styles/clsp-player.scss';
+@import '../../dist/clsp-player.css';
+
+// Or, to import SASS:
+// @import '../../src/styles/clsp-player.scss';
+
 @import './shared.scss';

--- a/demos/index.html
+++ b/demos/index.html
@@ -49,10 +49,10 @@
     </div>
 
     <script type="text/javascript">
-      document.title = `v${window.clspUtils.version} ${document.title}`;
+      document.title = `v${window.CLSP.utils.version} ${document.title}`;
 
       const pageTitle = document.getElementById('page-title').innerHTML;
-      document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.clspUtils.version}`;
+      document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.CLSP.utils.version}`;
     </script>
   </body>
 </html>

--- a/demos/simple-dist/index.html
+++ b/demos/simple-dist/index.html
@@ -36,7 +36,7 @@
           value="clsp://172.28.12.57:9001/FairfaxVideo0520"
         />
         <button
-          onclick="clspPlayerControls.changeSrc()"
+          onclick="window.clspPlayerControls.changeSrc()"
           title="Change Stream"
         >Change Stream</button>
       </div>
@@ -57,25 +57,25 @@
       </div>
       <div class="controls">
         <button
-          onclick="clspPlayerControls.play()"
+          onclick="window.clspPlayerControls.play()"
           title="play"
         >
           <i class="fas fa-play"></i>
         </button>
         <button
-          onclick="clspPlayerControls.stop()"
+          onclick="window.clspPlayerControls.stop()"
           title="stop"
         >
           <i class="fas fa-stop"></i>
         </button>
         <button
-          onclick="clspPlayerControls.fullscreen()"
+          onclick="window.clspPlayerControls.fullscreen()"
           title="fullscreen"
         >
           <i class="fas fa-expand"></i>
         </button>
         <button
-          onclick="clspPlayerControls.destroy()"
+          onclick="window.clspPlayerControls.destroy()"
           title="destroy"
         >
           <i class="fas fa-bomb"></i>
@@ -93,12 +93,12 @@
     ></script>
 
     <script>
-      document.title = `v${window.clspUtils.version} ${document.title}`;
+      document.title = `v${window.CLSP.utils.version} ${document.title}`;
 
       const pageTitle = document.getElementById('page-title').innerHTML;
-      document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.clspUtils.version}`;
+      document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.CLSP.utils.version}`;
 
-      clspPlayerControls.initialize();
+      window.clspPlayerControls.initialize();
     </script>
   </body>
 </html>

--- a/demos/simple-dist/index.js
+++ b/demos/simple-dist/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function play () {
-  if (!window.clspIov) {
+  if (!window.iov) {
     return;
   }
 
@@ -9,34 +9,34 @@ function play () {
 }
 
 function stop () {
-  if (!window.clspIov) {
+  if (!window.iov) {
     return;
   }
 
-  window.clspIov.stop();
+  window.iov.stop();
 }
 
 function fullscreen () {
-  if (!window.clspIov) {
+  if (!window.iov) {
     return;
   }
 
-  window.clspIov.toggleFullscreen();
+  window.iov.toggleFullscreen();
 }
 
 function destroy () {
-  if (!window.clspIov) {
+  if (!window.iov) {
     return;
   }
 
-  window.clspIovCollection.remove(window.clspIov.id);
-  window.clspIov = null;
+  window.iovCollection.remove(window.iov.id);
+  window.iov = null;
 }
 
 function changeSrc () {
   var streamUrl = document.getElementById('stream-src').value;
 
-  window.clspIov.changeSrc(streamUrl);
+  window.iov.changeSrc(streamUrl);
 }
 
 function initialize () {
@@ -47,12 +47,12 @@ function initialize () {
 
   document.getElementById('stream-src').value = url;
 
-  window.clspIovCollection = window.ClspIovCollection.asSingleton();
+  window.iovCollection = window.CLSP.IovCollection.asSingleton();
 
-  window.clspIovCollection.create(videoElementId)
-    .then(function (clspIov) {
-      window.clspIov = clspIov;
-      window.clspIov.changeSrc(url);
+  window.iovCollection.create(videoElementId)
+    .then(function (iov) {
+      window.iov = iov;
+      window.iov.changeSrc(url);
     })
     .catch(function (error) {
       document.getElementById('browser-not-supported').style.display = 'block';

--- a/demos/simple-src/index.html
+++ b/demos/simple-src/index.html
@@ -32,7 +32,7 @@
           value="clsp://172.28.12.57:9001/FairfaxVideo0520"
         />
         <button
-          onclick="clspPlayerControls.changeSrc()"
+          onclick="window.clspPlayerControls.changeSrc()"
           title="Change Stream"
         >Change Stream</button>
       </div>
@@ -53,25 +53,25 @@
       </div>
       <div class="controls">
         <button
-          onclick="clspPlayerControls.play()"
+          onclick="window.clspPlayerControls.play()"
           title="play"
         >
           <i class="fas fa-play"></i>
         </button>
         <button
-          onclick="clspPlayerControls.stop()"
+          onclick="window.clspPlayerControls.stop()"
           title="stop"
         >
           <i class="fas fa-stop"></i>
         </button>
         <button
-          onclick="clspPlayerControls.fullscreen()"
+          onclick="window.clspPlayerControls.fullscreen()"
           title="fullscreen"
         >
           <i class="fas fa-expand"></i>
         </button>
         <button
-          onclick="clspPlayerControls.destroy()"
+          onclick="window.clspPlayerControls.destroy()"
           title="destroy"
         >
           <i class="fas fa-bomb"></i>

--- a/demos/simple-src/index.js
+++ b/demos/simple-src/index.js
@@ -5,23 +5,32 @@ import $ from 'jquery';
 
 // simulate `import '@skylineos/clsp-player'`
 import {
-  ClspIovCollection,
-  clspUtils,
+  IovCollection,
+  utils,
 } from '~root/dist/clsp-player.min.js';
 
-let clspIovCollection;
-let clspIov;
+/**
+ * or with `require`....
+ *
+ * const {
+ *   IovCollection,
+ *   utils,
+ * } = require('~root/dist/clsp-player.min.js');
+ */
+
+let iovCollection;
+let iov;
 
 function displayVersions () {
-  document.title = `v${clspUtils.version} ${document.title}`;
+  document.title = `v${utils.version} ${document.title}`;
 
   const pageTitle = $('#page-title').html();
-  $('#page-title').html(`${pageTitle} <br /> v${clspUtils.version}`);
+  $('#page-title').html(`${pageTitle} <br /> v${utils.version}`);
 }
 
 function registerHandlers () {
   function play () {
-    if (!clspIov) {
+    if (!iov) {
       return;
     }
 
@@ -29,34 +38,34 @@ function registerHandlers () {
   }
 
   function stop () {
-    if (!clspIov) {
+    if (!iov) {
       return;
     }
 
-    clspIov.stop();
+    iov.stop();
   }
 
   function fullscreen () {
-    if (!clspIov) {
+    if (!iov) {
       return;
     }
 
-    clspIov.toggleFullscreen();
+    iov.toggleFullscreen();
   }
 
   function destroy () {
-    if (!clspIov) {
+    if (!iov) {
       return;
     }
 
-    clspIovCollection.remove(clspIov.id);
-    clspIov = null;
+    iovCollection.remove(iov.id);
+    iov = null;
   }
 
   function changeSrc () {
     const streamUrl = document.getElementById('stream-src').value;
 
-    clspIov.changeSrc(streamUrl);
+    iov.changeSrc(streamUrl);
   }
 
   window.clspPlayerControls = {
@@ -76,10 +85,10 @@ async function main () {
 
     document.getElementById('stream-src').value = url;
 
-    clspIovCollection = ClspIovCollection.asSingleton();
-    clspIov = await clspIovCollection.create(videoElementId);
+    iovCollection = IovCollection.asSingleton();
+    iov = await iovCollection.create(videoElementId);
 
-    clspIov.changeSrc(url);
+    iov.changeSrc(url);
   }
   catch (error) {
     document.getElementById('browser-not-supported').style.display = 'block';

--- a/demos/simple-src/styles.scss
+++ b/demos/simple-src/styles.scss
@@ -1,2 +1,8 @@
-@import '../../src/styles/clsp-player.scss';
+// Using relative path with parent directories here to allow this file to be
+// importable from a parent node project (e.g. @skylineos/videojs-clsp)
+@import '../../dist/clsp-player.css';
+
+// Or, to import SASS:
+// @import '../../src/styles/clsp-player.scss';
+
 @import '../simple-dist/styles.css';

--- a/demos/tour-dist/index.js
+++ b/demos/tour-dist/index.js
@@ -33,10 +33,10 @@ var initialStreams = [
 ];
 
 function displayVersions () {
-  document.title = `v${window.clspUtils.version} ${document.title}`;
+  document.title = `v${window.CLSP.utils.version} ${document.title}`;
 
   var pageTitle = document.getElementById('page-title').innerHTML;
-  document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.clspUtils.version}`;
+  document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${window.CLSP.utils.version}`;
 }
 
 function getTourList () {
@@ -86,8 +86,8 @@ function initialize () {
 
   var urls = getTourList();
 
-  var tour = window.ClspTourController.factory(
-    window.ClspIovCollection.asSingleton(),
+  var tour = window.CLSP.TourController.factory(
+    window.CLSP.IovCollection.asSingleton(),
     videoElementId,
     {
       intervalDuration: 10,

--- a/demos/tour-src/index.js
+++ b/demos/tour-src/index.js
@@ -6,10 +6,20 @@ import humanize from 'humanize';
 
 // simulate `import '@skylineos/clsp-player'`
 import {
-  ClspIovCollection,
-  ClspTourController,
-  clspUtils,
+  IovCollection,
+  TourController,
+  utils,
 } from '~root/dist/clsp-player.min.js';
+
+/**
+ * or with `require`....
+ *
+ * const {
+ *   IovCollection,
+ *   TourController,
+ *   utils,
+ * } = require('~root/dist/clsp-player.min.js');
+ */
 
 let durationDisplayInterval;
 
@@ -44,10 +54,10 @@ const initialStreams = [
 ];
 
 function displayVersions () {
-  document.title = `v${clspUtils.version} ${document.title}`;
+  document.title = `v${utils.version} ${document.title}`;
 
   const pageTitle = document.getElementById('page-title').innerHTML;
-  document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${clspUtils.version}`;
+  document.getElementById('page-title').innerHTML = `${pageTitle} <br /> v${utils.version}`;
 }
 
 function getTourList () {
@@ -97,8 +107,8 @@ $(() => {
 
   const urls = getTourList();
 
-  const tour = ClspTourController.factory(
-    ClspIovCollection.asSingleton(),
+  const tour = TourController.factory(
+    IovCollection.asSingleton(),
     videoElementId,
     {
       intervalDuration: 10,

--- a/demos/tour-src/styles.scss
+++ b/demos/tour-src/styles.scss
@@ -1,2 +1,8 @@
-@import '../../src/styles/clsp-player.scss';
+// Using relative path with parent directories here to allow this file to be
+// importable from a parent node project (e.g. @skylineos/videojs-clsp)
+@import '../../dist/clsp-player.css';
+
+// Or, to import SASS:
+// @import '../../src/styles/clsp-player.scss';
+
 @import '../tour-dist/styles.css';

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,120 @@
+/**
+ * Responsible for receiving stream input and routing it to the media source
+ * buffer for rendering on the video tag. There is some 'light' reworking of
+ * the binary data that is required.
+*/
+export class IovPlayer {
+    static factory(logId, videoElement,onConduitMessageError?: Function, onPlayerError?: Function ): IovPlayer;
+    on(name, action);
+    trigger (name, value);
+    metric (type, value);
+    generateConduitLogId(): string;
+    onConduitReconnect: (error) => void;
+    onPlayerError: (error) => void;
+    onConduitMessageError: (error) => void;
+    initialize (streamConfiguration): Promise<void>;
+    reinitializeMseWrapper(mimeCodec): Promise<void>;
+    restart(): Promise<void>;
+    onMoof: (clspMessage) => void;
+    play(): Promise<void>;
+    stop(): Promise<void>;
+    getSegmentIntervalMetrics();
+    enterFullscreen();
+    exitFullscreen();
+    toggleFullscreen();
+    destroy(): Promise<void>;
+}
+
+/**
+ * Internet of Video client. This module uses the MediaSource API to
+ * deliver video content streamed through CLSP from distributed sources.
+ */
+export class Iov {
+    on(eventName: string, action: any);
+    trigger(eventName: string, value: any);
+    metric(eventName: string, value: any);
+    onConnectionChange();
+    onVisibilityChange():Promise<void>;
+    generatePlayerLogId(): string;
+    showNextStream();
+    cancelChangeSrc(id: string);
+    play(iovPlayer?: IovPlayer):Promise<void>;
+    stop(iovPlayer?: IovPlayer):Promise<void>;
+    restart(iovPlayer?: IovPlayer):Promise<void>;
+    enterFullscreen(iovPlayer?: IovPlayer):Promise<void>;
+    exitFullscreen(iovPlayer?: IovPlayer):Promise<void>;
+    toggleFullscreen(iovPlayer?: IovPlayer):Promise<void>;
+    changeSrc(url: string, showOnFirstFrame?: boolean);
+    clone(streamConfiguration?);
+    onPlayerError(error);
+    /**
+     * Dereference the necessary properties, clear any intervals and timeouts, and
+     * remove any listeners.  Will also destroy the player.
+     */
+    destroy();
+}
+
+/**
+ * The Iov Collection is meant to be a singleton, and is meant to manage all
+ * Iovs in a given browser window/document.  There are certain centralized
+ * functions it is meant to perform, such as generating the guids that are
+ * needed to establish a connection to a unique topic on the SFS, and to listen
+ * to window messages and route the relevant messages to the appropriate Iov
+ * instance.
+ */
+export class IovCollection {
+    static asSingleton():IovCollection;
+    /**
+     * Create an Iov for a specific stream, and add it to this collection.
+     */
+    create(videoElementId: string): Promise<Iov>;
+    /**
+     * Add an Iov instance to this collection.  It can then be accessed by its id.
+     */
+    add(iov: Iov);
+    /**
+     * Determine whether or not an iov with the passed id exists in this
+     * collection.
+     */
+    has(iovId: string):boolean;
+    /**
+     * Get an iov with the passed id from this collection.
+     */
+    get(iovId: string):Iov | undefined;
+    /**
+     * Remove an iov instance from this collection and destroy it.
+     */
+    remove(iovId: string):this;
+    /**
+     * Destroy this collection and destroy all iov instances in this collection.
+     */
+    destroy();
+}
+
+export class TourController {
+    static factory(IovCollection: IovCollection, videoElementId: string, options?: {onLoad?: Function, onShown?: Function}): TourController;
+    addUrls(urls: Array<string>);
+    next(playImmediately?: boolean, resetTimer?: boolean): Promise<void>;
+    previous(): Promise<void>;
+    resume(force?: boolean, wait?: boolean): Promise<void>;
+    start(): Promise<void>;
+    pause();
+    stop();
+    reset(): Promise<void>;
+    fullscreen();
+    destroy();
+}
+
+export class ClspUtils {
+    static version: string;
+    static name: string;
+    static supported: () => boolean;
+    static windowStateNames: { hiddenStateName: string, visibilityChangeEventName: string };
+    static DEFAULT_STREAM_TIMEOUT: number;
+    static MINIMUM_CHROME_VERSION: number;
+    static SUPPORTED_MIME_TYPE: string;
+    static mediaSourceExtensionsCheck(): { hiddenStateName: string, visibilityChangeEventName: string };
+    static isSupportedMimeType(): boolean;
+    static getDefaultStreamPort(): number;
+    static setDefaultStreamPort(protocol: string, port: number);
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,16 @@
+// Type definitions for CLSP
+// Project: @skylineos/clsp-player
+
+// @see - https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
+
+export as namespace CLSP;
+
 /**
  * Responsible for receiving stream input and routing it to the media source
  * buffer for rendering on the video tag. There is some 'light' reworking of
  * the binary data that is required.
 */
-export class IovPlayer {
+interface IovPlayer {
     static factory(logId, videoElement,onConduitMessageError?: Function, onPlayerError?: Function ): IovPlayer;
     on(name, action);
     trigger (name, value);
@@ -105,9 +112,9 @@ export class TourController {
     destroy();
 }
 
-export class ClspUtils {
-    static version: string;
+export class utils {
     static name: string;
+    static version: string;
     static supported: () => boolean;
     static windowStateNames: { hiddenStateName: string, visibilityChangeEventName: string };
     static DEFAULT_STREAM_TIMEOUT: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,20 @@
-// Type definitions for CLSP
-// Project: @skylineos/clsp-player
+// Type definitions for CLSP Player
+// Project: https://github.com/skylineos/clsp-player
 
 // @see - https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html
+// @see - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts
 
 export as namespace CLSP;
 
 /**
- * @see - src/iov/IovPlayer.js
+ * defined in src/iov/IovPlayer.js
  *
  * Responsible for receiving stream input and routing it to the media source
  * buffer for rendering on the video tag. There is some 'light' reworking of
  * the binary data that is required.
 */
 interface IovPlayer {
-    static factory(logId, videoElement,onConduitMessageError?: Function, onPlayerError?: Function ): IovPlayer;
+    static factory(logId, videoElement, onConduitMessageError?: Function, onPlayerError?: Function ): IovPlayer;
     on(name, action);
     trigger (name, value);
     metric (type, value);
@@ -114,16 +115,20 @@ export class TourController {
     destroy();
 }
 
+interface PageVisibilityApiPropertyNames {
+    hiddenStateName: string;
+    visibilityChangeEventName: string;
+}
+
 export class utils {
     static name: string;
     static version: string;
-    static supported: () => boolean;
-    static windowStateNames: { hiddenStateName: string, visibilityChangeEventName: string };
-    static DEFAULT_STREAM_TIMEOUT: number;
     static MINIMUM_CHROME_VERSION: number;
     static SUPPORTED_MIME_TYPE: string;
-    static mediaSourceExtensionsCheck(): { hiddenStateName: string, visibilityChangeEventName: string };
+    static DEFAULT_STREAM_TIMEOUT: number;
+    static supported(): boolean;
     static isSupportedMimeType(): boolean;
+    static windowStateNames: PageVisibilityApiPropertyNames;
     static getDefaultStreamPort(): number;
     static setDefaultStreamPort(protocol: string, port: number);
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,13 +22,29 @@ interface StreamConfigurationConfig {
 }
 
 /**
+ * Defined in /src/js/iov/StreamConfiguration.js
+ */
+declare class StreamConfiguration {
+    static factory(streamName: string, host: string, port: number, useSSL: boolean, tokenConfig: StreamConfigurationTokenConfig): StreamConfiguration;
+    static fromObject(config): StreamConfiguration;
+    static isStreamConfiguration(target: any): boolean;
+    static generateConfigFromUrl(url: string): StreamConfigurationConfig;
+    static fromUrl(url): StreamConfiguration;
+    protocol: string;
+    url: string;
+    clone(streamConfiguration: StreamConfiguration): StreamConfiguration;
+    toObject(): StreamConfigurationConfig;
+    destroy();
+}
+
+/**
  * defined in src/iov/IovPlayer.js
  *
  * Responsible for receiving stream input and routing it to the media source
  * buffer for rendering on the video tag. There is some 'light' reworking of
  * the binary data that is required.
 */
-interface IovPlayer {
+declare class IovPlayer {
     static factory(logId: string, videoElement, onConduitMessageError?: Function, onPlayerError?: Function): IovPlayer;
     on(name: string, action: Function);
     initialize (streamConfiguration: StreamConfigurationToken): Promise<void>;
@@ -40,22 +56,6 @@ interface IovPlayer {
     exitFullscreen();
     toggleFullscreen();
     destroy(): Promise<void>;
-}
-
-/**
- * Defined in /src/js/iov/StreamConfiguration.js
- */
-interface StreamConfiguration {
-    static factory(streamName: string, host: string, port: number, useSSL: boolean, tokenConfig: StreamConfigurationTokenConfig): StreamConfiguration;
-    static fromObject(config): StreamConfiguration;
-    static isStreamConfiguration(target: any): boolean;
-    static generateConfigFromUrl(url: string): StreamConfigurationConfig;
-    static fromUrl(url): StreamConfiguration;
-    protocol: string;
-    url: string;
-    clone(streamConfiguration: StreamConfiguration): StreamConfiguration;
-    toObject(): StreamConfigurationConfig;
-    destroy();
 }
 
 interface IovChangeSrcReturnValue {

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@
 export as namespace CLSP;
 
 /**
+ * @see - src/iov/IovPlayer.js
+ *
  * Responsible for receiving stream input and routing it to the media source
  * buffer for rendering on the video tag. There is some 'light' reworking of
  * the binary data that is required.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "sass-loader": "8.0.2",
     "standard": "14.3.3",
     "style-loader": "1.1.3",
+    "typescript": "3.9.6",
     "url-loader": "4.0.0",
     "webpack": "4.43.0",
     "webpack-bundle-analyzer": "3.8.0",

--- a/scripts/webpack-utils/BuildCompiler.js
+++ b/scripts/webpack-utils/BuildCompiler.js
@@ -193,8 +193,6 @@ module.exports = class BuildCompiler {
     }
 
     this.clearTimer();
-
-    return;
   }
 
   /**

--- a/scripts/webpack-utils/WebpackDevServer.js
+++ b/scripts/webpack-utils/WebpackDevServer.js
@@ -77,7 +77,7 @@ module.exports = class WebpackDevServer {
       stats: false,
 
       // Allow the caller to override or add devServerConfig properties
-      ...(config.devServerConfig || {})
+      ...(config.devServerConfig || {}),
     };
 
     this.server = new _WebpackDevServer(this.watchCompiler.compiler, this.devServerConfig);

--- a/src/js/conduit/Conduit.js
+++ b/src/js/conduit/Conduit.js
@@ -333,10 +333,10 @@ export default class Conduit {
     // @todo - should connect be called here?
     await this.connect();
 
-    //if (this.streamConfiguration.hash && this.streamConfiguration.hash.length > 0) {
     if (this.streamConfiguration.tokenConfig &&
         this.streamConfiguration.tokenConfig.hash &&
-        this.streamConfiguration.tokenConfig.hash.length > 0 ) {
+        this.streamConfiguration.tokenConfig.hash.length > 0
+    ) {
       this.streamName = await this.validateHash();
     }
 
@@ -527,14 +527,14 @@ export default class Conduit {
       b64HashURL: this.streamConfiguration.tokenConfig.b64HashAccessUrl,
       token: this.streamConfiguration.tokenConfig.hash,
     });
-     
+
     if (response.status === 401) {
       throw new Error('HashUnAuthorized');
     }
 
     if (response.status !== 200) {
       throw new Error('HashInvalid');
-    } 
+    }
 
     // TODO, figure out how to handle a change in the sfs url from the
     // clsp-hash from the target url returned from decrypting the hash

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,14 +2,14 @@ import '../styles/clsp-player.scss';
 
 import 'srcdoc-polyfill';
 
-import ClspIov from './iov/Iov';
-import ClspIovCollection from './iov/IovCollection';
-import ClspTourController from './iov/TourController';
-import clspUtils from './utils/utils';
+import Iov from './iov/Iov';
+import IovCollection from './iov/IovCollection';
+import TourController from './iov/TourController';
+import utils from './utils/utils';
 
 export {
-  ClspIov,
-  ClspIovCollection,
-  ClspTourController,
-  clspUtils,
+  Iov,
+  IovCollection,
+  TourController,
+  utils,
 };

--- a/src/js/iov/Iov.js
+++ b/src/js/iov/Iov.js
@@ -267,7 +267,7 @@ export default class Iov {
     }
   }
 
-  cancelChangeSrc (id) {
+  cancelChangeSrc () {
     if (!this.pendingChangeSrcIovPlayer) {
       return;
     }
@@ -466,7 +466,7 @@ export default class Iov {
     this.logger.debug('destroy');
 
     if (this.destroyed) {
-      return;
+      return Promise.resolve();
     }
 
     this.destroyed = true;

--- a/src/js/iov/IovCollection.js
+++ b/src/js/iov/IovCollection.js
@@ -50,10 +50,12 @@ export default class IovCollection {
    * @returns {Iov}
    */
   async create (videoElementId) {
-    const iov = Iov.factory(videoElementId,
+    const iov = Iov.factory(
+      videoElementId,
       {
         id: (++totalIovCount).toString(),
-      });
+      }
+    );
 
     this.add(iov);
 

--- a/src/js/iov/IovCollection.js
+++ b/src/js/iov/IovCollection.js
@@ -54,7 +54,7 @@ export default class IovCollection {
       videoElementId,
       {
         id: (++totalIovCount).toString(),
-      }
+      },
     );
 
     this.add(iov);

--- a/src/js/iov/IovPlayer.js
+++ b/src/js/iov/IovPlayer.js
@@ -428,6 +428,7 @@ export default class IovPlayer {
 
     const playError = await this.play();
 
+    // @todo - should this throw?
     if (playError) {
       return playError;
     }
@@ -639,7 +640,7 @@ export default class IovPlayer {
     this.logger.debug('destroy...');
 
     if (this.destroyed) {
-      return;
+      return Promise.resolve();
     }
 
     this.destroyed = true;

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -233,6 +233,7 @@ module.exports = {
   name,
   version,
   MINIMUM_CHROME_VERSION,
+  SUPPORTED_MIME_TYPE,
   DEFAULT_STREAM_TIMEOUT,
   supported: isBrowserCompatable,
   isSupportedMimeType,

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -173,6 +173,15 @@ function isSupportedMimeType (mimeType) {
 function getWindowStateNames () {
   logger.debug('Determining Page_Visibility_API property names.');
 
+  // @todo - this check is needed to support these utils being imported by
+  // webpack.  there is probably a more elegant way to handle this scenario.
+  if (typeof document === 'undefined') {
+    return {
+      hiddenStateName: '',
+      visibilityChangeEventName: '',
+    };
+  }
+
   // @see - https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API
   if (typeof document.hidden !== 'undefined') {
     logger.debug('Using standard Page_Visibility_API property names.');

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -5,43 +5,78 @@
  * by webpack.
  */
 
-const {
-  version,
-  name,
-} = require('../../../package.json');
+const packageJson = require('../../../package.json');
 
 const Logger = require('./logger');
 
 // @todo - remove this side-effect
 const logger = Logger().factory();
 
-const MINIMUM_CHROME_VERSION = 53;
-
-// @todo - this mime type, though used in the videojs plugin, and
-// seemingly enforced, is not actually enforced.  The only enforcement
-// done is requiring the user provide this string on the video element
-// in the DOM.  The codecs that are supplied by the SFS's vary.  Here
-// are some "valid", though not enforced mimeCodec values I have come
-// across:
-// video/mp4; codecs="avc1.4DE016"
-// video/mp4; codecs="avc1.42E00C"
-// video/mp4; codecs="avc1.42E00D"
-const SUPPORTED_MIME_TYPE = "video/mp4; codecs='avc1.42E01E'";
-
-// The streams must not timeout earlier than this to be able to support Vero
-// tours and high-quality streams.
-const DEFAULT_STREAM_TIMEOUT = 20;
-
 // CLSP default port for SFS >= 5.2.0 is 80
 // CLSP default port for SFS < 5.2.0 is 9001
 const DEFAULT_CLSP_PORT = 80;
 const DEFAULT_CLSPS_PORT = 443;
 
+// Locally-scoped value that maintains the clsp and clsps port states.
+//
+// @see - getDefaultStreamPort
+// @see - setDefaultStreamPort
+//
 // @todo - state / config could be managed better than this
 const streamPorts = {
   clsp: DEFAULT_CLSP_PORT,
   clsps: DEFAULT_CLSPS_PORT,
 };
+
+/**
+ * The name of the CLSP Player library as defined in `package.json` without the
+ * group name.
+ *
+ * @type {String}
+ */
+const name = packageJson.name.split('/').pop();
+
+/**
+ * The version of the CLSP Player library.  Follows semver.
+ *
+ * @type {String}
+ */
+const version = packageJson.version;
+
+/**
+ * The oldest Chrome browser version supported by CLSP Player.
+ *
+ * @type {Number}
+ */
+const MINIMUM_CHROME_VERSION = 53;
+
+/**
+ * The MIME type required for CLSP Player to be able to play the stream.
+ *
+ * @todo - this mime type, though used in the videojs plugin, and
+ * seemingly enforced, is not actually enforced.  The only enforcement
+ * done is requiring the user provide this string on the video element
+ * in the DOM.  The codecs that are supplied by the SFS's vary.  Here
+ * are some "valid", though not enforced mimeCodec values I have come
+ * across:
+ * - video/mp4; codecs="avc1.4DE016"
+ * - video/mp4; codecs="avc1.42E00C"
+ * - video/mp4; codecs="avc1.42E00D"
+ *
+ * @type {String}
+ */
+const SUPPORTED_MIME_TYPE = "video/mp4; codecs='avc1.42E01E'";
+
+/**
+ * The amount of time (in seconds) before a stream times out.
+ *
+ * Note that this timeout value should be treated as the minimum value to
+ * support Vero tours and high-quality streams.
+ *
+ * @type {Number}
+ */
+const DEFAULT_STREAM_TIMEOUT = 20;
+
 
 function isBrowserCompatable () {
   try {
@@ -164,15 +199,15 @@ function setDefaultStreamPort (protocol, port) {
 }
 
 module.exports = {
+  name,
   version,
-  name: name.split('/').pop(),
+  MINIMUM_CHROME_VERSION,
+  SUPPORTED_MIME_TYPE,
+  DEFAULT_STREAM_TIMEOUT,
   supported: isBrowserCompatable,
   mediaSourceExtensionsCheck,
   isSupportedMimeType,
   windowStateNames: _getWindowStateNames(),
   getDefaultStreamPort,
   setDefaultStreamPort,
-  DEFAULT_STREAM_TIMEOUT,
-  MINIMUM_CHROME_VERSION,
-  SUPPORTED_MIME_TYPE,
 };

--- a/webpack.clsp-player.js
+++ b/webpack.clsp-player.js
@@ -20,6 +20,7 @@ const clspPlayerConfig = generateConfig(
 );
 
 // @see - https://webpack.js.org/configuration/output/#module-definition-systems
+clspPlayerConfig.output.library = 'CLSP';
 clspPlayerConfig.output.libraryTarget = 'umd';
 
 module.exports = function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6928,6 +6928,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
Currently, typescript index file is up to date with top comments, namespace, and utils definition.  All other definitions need to be audited (which I will handle shortly).

I was able to add all exports from the index file to a CLSP object that gets attached to the window via a webpack config.  Doing this meant that the exports from the index file no longer needed the prefix of "Clsp", so those changes were reverted.

The utils file was jsdoc'd and some things consolidated and moved around.