### PR TITLE
Work with Angular optimized builds

### DIFF
--- a/src/js/iov/StreamConfiguration.js
+++ b/src/js/iov/StreamConfiguration.js
@@ -28,7 +28,7 @@ export default class StreamConfiguration {
   }
 
   static isStreamConfiguration (target) {
-    return target && target.constructor && target.constructor.name === 'StreamConfiguration';
+    return target && target.constructor && target instanceof StreamConfiguration;
   }
 
   static generateConfigFromUrl (url) {


### PR DESCRIPTION
Using constructor.name makes the library incompatible with Angular optimized builds.
See https://github.com/angular/angular-cli/issues/5168
Fix the isStreamConfiguration method so that it no longer uses constructor.name and 
use instanceof instead.