### PR TITLE
repair stream frozen re-init logic (bosch black stream)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -90,6 +90,7 @@ module.exports = {
     // @see - https://jestjs.io/docs/en/webpack#handling-static-assets
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/jest/__mocks__/fileMock.js",
     "\\.(css|less|sass|scss)$": "<rootDir>/test/jest/__mocks__/styleMock.js",
+    "^MediaSource$": "<rootDir>/src/js/iov/Player/MSE/__mocks__/MediaSourceMock.js",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader

--- a/src/js/iov/Player/IovPlayer.js
+++ b/src/js/iov/Player/IovPlayer.js
@@ -6,7 +6,7 @@ import utils from '../../utils/utils';
 
 import ClspClient from '../../ClspClient/ClspClient';
 import MSEWrapper from './MSE/MSEWrapper';
-import MediaSource from './MSE/MediaSource';
+import MediaSourceWrapper from './MSE/MediaSourceWrapper';
 import StreamConfiguration from '../StreamConfiguration';
 import Conduit from '../../ClspClient/Conduit/Conduit';
 
@@ -359,7 +359,7 @@ export default class IovPlayer extends EventEmitter {
         moov,
       } = await this.clspClient.conduit.play();
 
-      if (!MediaSource.isMimeCodecSupported(mimeCodec)) {
+      if (!MediaSourceWrapper.isMimeCodecSupported(mimeCodec)) {
         this.emit(IovPlayer.events.UNSUPPORTED_MIME_CODEC, {
           mimeCodec,
         });
@@ -596,7 +596,7 @@ export default class IovPlayer extends EventEmitter {
 
       // Error events
 
-      this.mseWrapper.mediaSource.on(MediaSource.events.SOURCE_OPEN_ERROR, ({ error }) => {
+      this.mseWrapper.mediaSource.on(MediaSourceWrapper.events.SOURCE_OPEN_ERROR, ({ error }) => {
         this.logger.error('Failed to initialize mediaSource - Error on "sourceopen" event:');
         this.logger.error(error);
 
@@ -608,7 +608,7 @@ export default class IovPlayer extends EventEmitter {
 
       // When the MediaSource first becomes ready, send it the moov
       // @todo - all of this logic should be handled by the MSEWrapper!!
-      this.mseWrapper.mediaSource.on(MediaSource.events.SOURCE_OPEN, async (event) => {
+      this.mseWrapper.mediaSource.on(MediaSourceWrapper.events.SOURCE_OPEN, async (event) => {
         this.logger.info('on mediaSource sourceopen');
 
         try {
@@ -650,7 +650,7 @@ export default class IovPlayer extends EventEmitter {
         }
       });
 
-      this.mseWrapper.mediaSource.on(MediaSource.events.SOURCE_ENDED, async (event) => {
+      this.mseWrapper.mediaSource.on(MediaSourceWrapper.events.SOURCE_ENDED, async (event) => {
         this.logger.info('on mediaSource sourceended');
 
         try {

--- a/src/js/iov/Player/MSE/MSEWrapper.js
+++ b/src/js/iov/Player/MSE/MSEWrapper.js
@@ -349,7 +349,7 @@ export default class MSEWrapper extends EventEmitter {
     // however we can be less intrusive for now as a check for < 1 to catch the current case that's causing
     // black streams. bufferTimeEnd was not incrementing due to improper handling of multiple TimeRanges
     // if (this.previousTimeEnd == 0 && info.bufferTimeEnd <= this.previousTimeEnd) {
-    if (this.previousTimeEnd < 1 && info.bufferTimeEnd <= this.previousTimeEnd) {
+    if (info.bufferTimeEnd <= this.previousTimeEnd) {
       this.logger.info('previoustimeend: ' + this.previousTimeEnd + ', buffertimeend: ' + info.bufferTimeEnd);
       this.appendsSinceTimeEndUpdated += 1;
       this.metric('sourceBuffer.updateEnd.bufferFrozen', 1);

--- a/src/js/iov/Player/MSE/MSEWrapper.js
+++ b/src/js/iov/Player/MSE/MSEWrapper.js
@@ -211,8 +211,7 @@ export default class MSEWrapper extends EventEmitter {
       this.logger.debug('Tab not in focus - dropping frame...');
       this.metric('frameDrop.hiddenTab', 1);
       this.metric('queue.cannotProcessNext', 1);
-      // @todo - we can safely drop frames here, right?
-      // this.segmentQueue.shift();
+      this.segmentQueue.shift();
       return;
     }
 
@@ -221,8 +220,7 @@ export default class MSEWrapper extends EventEmitter {
       this.logger.info('The mediaSource is not ready');
       this.metric('queue.mediaSourceNotReady', 1);
       this.metric('queue.cannotProcessNext', 1);
-      // @todo - we can safely drop frames here, right?
-      // this.segmentQueue.shift();
+      this.segmentQueue.shift();
       return;
     }
 
@@ -238,8 +236,7 @@ export default class MSEWrapper extends EventEmitter {
       this.logger.debug('The sourceBuffer is not ready');
       this.metric('queue.sourceBufferNotReady', 1);
       this.metric('queue.cannotProcessNext', 1);
-      // @todo - we can safely drop frames here, right?
-      // this.segmentQueue.shift();
+      this.segmentQueue.shift();
       return;
     }
 
@@ -343,21 +340,23 @@ export default class MSEWrapper extends EventEmitter {
     // The current buffer size should always be bigger.If it isn't, there is a problem,
     // and we need to reinitialize or something.  Sometimes the buffer is the same.  This is
     // allowed for consecutive appends, but only a configurable number of times.  The default
-    // is 1
+    // is 1.  It's possible we don't properly handle time gaps in fragments.  
+    // This is why the bosch camera has issues when in IBP or IBBP.
     this.logger.debug('Appends with same time end: ' + this.appendsSinceTimeEndUpdated);
 
     // have seen video moofs with a previousTimeEnd in the sub 1 range 0.034, new segments getting processed,
-    // but bufferTimeEnd not incrementing. Might be able to remove this.previousTimeEnd check 
+    // but bufferTimeEnd not incrementing. Might be able to remove this.previousTimeEnd check
     // however we can be less intrusive for now as a check for < 1 to catch the current case that's causing black streams.
-    // if (this.previousTimeEnd < 1 && info.bufferTimeEnd <= this.previousTimeEnd) {
-    if (info.bufferTimeEnd <= this.previousTimeEnd) {
-      this.logger.error('BUF previoustimeend: ' + this.previousTimeEnd + ', buffertimeend: ' + info.bufferTimeEnd);
+    // bufferTimeEnd not incrementing due to improper handling of multiple TimeRanges
+    // if (this.previousTimeEnd == 0 && info.bufferTimeEnd <= this.previousTimeEnd) {
+    if (this.previousTimeEnd < 1 && info.bufferTimeEnd <= this.previousTimeEnd) {
+      this.logger.info('previoustimeend: ' + this.previousTimeEnd + ', buffertimeend: ' + info.bufferTimeEnd);
       this.appendsSinceTimeEndUpdated += 1;
       this.metric('sourceBuffer.updateEnd.bufferFrozen', 1);
 
       // append threshold with same time end has been crossed.  Reinitialize frozen stream.
       if (this.appendsSinceTimeEndUpdated > this.APPENDS_WITH_SAME_TIME_END_THRESHOLD) {
-        this.logger.info('Stream frozen. Reinitializing');
+        this.logger.warn('Stream frozen. Reinitializing');
         this.emit(MSEWrapper.events.STREAM_FROZEN);
       }
       return;
@@ -369,7 +368,7 @@ export default class MSEWrapper extends EventEmitter {
     this.emit(MSEWrapper.events.VIDEO_SEGMENT_SHOWN, { info });
 
     try {
-      this.sourceBuffer.trim(info);
+      this.sourceBuffer.trim();
     }
     catch (error) {
       this.#onSourceBufferTrimError(error);
@@ -383,18 +382,10 @@ export default class MSEWrapper extends EventEmitter {
 
     // @todo - it is likely possible to move the use of info here into the
     // SourceBuffer implementation to reduce coupling
-    const info = this.sourceBuffer.getTimes();
+    const infoAry = this.sourceBuffer.getTimes();
+    const latestInfo = infoAry[infoAry.length - 1];
+    this.#onVideoSegmentShown(latestInfo);
 
-    if (info.previousBufferSize !== null && info.previousBufferSize > this.sourceBuffer.timeBuffered) {
-      // @todo - it appears that at one time, this was used for something,
-      // maybe it was only ever for metrics.  What does this condition mean
-      // in layman's terms, other than "a video segment was not shown as the
-      // result of this sourceBuffer update"?
-      this.metric('sourceBuffer.updateEnd.removeEvent', 1);
-    }
-    else {
-      this.#onVideoSegmentShown(info);
-    }
 
     try {
       this.#processNextInQueue();

--- a/src/js/iov/Player/MSE/MediaSourceWrapper.js
+++ b/src/js/iov/Player/MSE/MediaSourceWrapper.js
@@ -4,7 +4,6 @@
  * @see - https://developers.google.com/web/fundamentals/media/mse/basics
  * @see - https://github.com/nickdesaulniers/netfix/blob/gh-pages/demo/bufferAll.html
  */
-
 import interval from 'interval-promise';
 
 import EventEmitter from '../../../utils/EventEmitter';
@@ -15,9 +14,9 @@ const DEFAULT_IS_READY_INTERVAL = 0.25;
 // Give the MediaSource this many seconds to become ready
 const DEFAULT_IS_READY_TIMEOUT = 1;
 
-export default class MediaSource extends EventEmitter {
+export default class MediaSourceWrapper extends EventEmitter {
   /**
-   * Events that are emitted by this MediaSource
+   * Events that are emitted by this MediaSourceWrapper
    */
   static events = {
     // --- Custom events
@@ -53,23 +52,23 @@ export default class MediaSource extends EventEmitter {
   }
 
   /**
-   * Create a new MediaSource, which is a wrapper around `window.MediaSource`
+   * Create a new MediaSourceWrapper, which is a wrapper around `window.MediaSource`
    *
    * @param {string|object} logId
    *   a string that identifies this MediaSource in log messages
    *   @see - src/js/utils/Destroyable
    */
   static factory (logId) {
-    return new MediaSource(logId);
+    return new MediaSourceWrapper(logId);
   }
 
   /**
    * @private
    *
-   * Create a new MediaSource, which is a wrapper around `window.MediaSource`
+   * Create a new MediaSourceWrapper, which is a wrapper around `window.MediaSource`
    *
    * @param {string|object} logId
-   *   a string that identifies this MediaSource in log messages
+   *   a string that identifies this MediaSourceWrapper in log messages
    *   @see - src/js/utils/Destroyable
    */
   constructor (logId) {
@@ -205,7 +204,7 @@ export default class MediaSource extends EventEmitter {
       await this.waitUntilReady();
     }
     catch (error) {
-      this.emit(MediaSource.events.SOURCE_OPEN_ERROR, { error });
+      this.emit(MediaSourceWrapper.events.SOURCE_OPEN_ERROR, { error });
       return;
     }
 
@@ -220,12 +219,12 @@ export default class MediaSource extends EventEmitter {
       this.logger.error(`Error while setting mediaSource duration to "${this.DURATION}"`);
       this.logger.error(error);
 
-      this.emit(MediaSource.events.SOURCE_OPEN_ERROR, { error });
+      this.emit(MediaSourceWrapper.events.SOURCE_OPEN_ERROR, { error });
 
       return;
     }
 
-    this.emit(MediaSource.events.SOURCE_OPEN, event);
+    this.emit(MediaSourceWrapper.events.SOURCE_OPEN, event);
   };
 
   /**
@@ -245,7 +244,7 @@ export default class MediaSource extends EventEmitter {
    * @returns {void}
    */
   #onSourceEnded = (event) => {
-    this.emit(MediaSource.events.SOURCE_ENDED, event);
+    this.emit(MediaSourceWrapper.events.SOURCE_ENDED, event);
   };
 
   /**
@@ -259,7 +258,7 @@ export default class MediaSource extends EventEmitter {
    * @returns {void}
    */
   #onError = (event) => {
-    this.emit(MediaSource.events.ERROR, event);
+    this.emit(MediaSourceWrapper.events.ERROR, event);
   };
 
   /**

--- a/src/js/iov/Player/MSE/SourceBuffer.js
+++ b/src/js/iov/Player/MSE/SourceBuffer.js
@@ -246,7 +246,7 @@ export default class SourceBuffer extends EventEmitter {
     const bufferedRanges = this.sourceBuffer.buffered;
 
     // only a single range present
-    if (bufferedRanges.length <= rangeIndex + 1) {
+    if (bufferedRanges.length <= 1) {
       return false;
     }
 
@@ -279,10 +279,10 @@ export default class SourceBuffer extends EventEmitter {
       const previousBufferSize = this.timeBuffered;
       const bufferedRanges = this.sourceBuffer.buffered;
 
-      this.logger.warn('this.sourceBuffer.buffered length: ' + bufferedRanges.length);
+      this.logger.debug('this.sourceBuffer.buffered length: ' + bufferedRanges.length);
 
-      for (let i = 0; i < bufferedRanges.length; i++) {        
-        this.logger.warn(`Range ${i}: ${bufferedRanges.start(i)} to ${bufferedRanges.end(i)} seconds`);
+      for (let i = 0; i < bufferedRanges.length; i++) {
+        this.logger.info(`Range ${i}: ${bufferedRanges.start(i)} to ${bufferedRanges.end(i)} seconds`);
         const bufferTimeStart = bufferedRanges.start(i);
         const bufferTimeEnd = bufferedRanges.end(i);
         const currentBufferSize = bufferTimeEnd - bufferTimeStart;

--- a/src/js/iov/Player/MSE/SourceBuffer.js
+++ b/src/js/iov/Player/MSE/SourceBuffer.js
@@ -109,7 +109,6 @@ export default class SourceBuffer extends EventEmitter {
     this.mediaSource = mediaSource;
     // @todo - should the MediaSource be responsible for this?
     this.sourceBuffer = this.mediaSource.mediaSource.addSourceBuffer(this.mimeCodec);
-
     this.sourceBuffer.mode = 'sequence';
 
     this.sourceBuffer.addEventListener('updateend', this.#onUpdateEnd);
@@ -204,6 +203,11 @@ export default class SourceBuffer extends EventEmitter {
     // this.metric('sourceBuffer.append', 1);
 
     try {
+      // never encountered this block but docs say you shouldn't append when the sourcebuffer is  updating
+      if (this.sourceBuffer.updating) {
+        this.logger.warn('Source buffer is still updating! Cannot append!');
+        return;
+      }
       this.sourceBuffer.appendBuffer(byteArray);
     }
     catch (error) {
@@ -237,6 +241,27 @@ export default class SourceBuffer extends EventEmitter {
     this.shouldAbortOnNextUpdateEnd = true;
   }
 
+  /** Detect a gap in the buffered time ranges */
+  gapInBufferedRanges (rangeIndex) {
+    const bufferedRanges = this.sourceBuffer.buffered;
+
+    // only a single range present
+    if (bufferedRanges.length <= rangeIndex + 1) {
+      return false;
+    }
+
+    const currentEnd = bufferedRanges.end(rangeIndex);
+    const nextStart = bufferedRanges.start(rangeIndex + 1);
+
+    // compare against the next range and see if there's a hole
+    const gap = nextStart - currentEnd;
+    if (gap > 0) {
+      return true;
+    }
+
+    return false;
+  }
+
   /**
    * Calculate size and time information about the current state of the buffer.
    *
@@ -248,23 +273,31 @@ export default class SourceBuffer extends EventEmitter {
     }
 
     this.logger.silly('getBufferTimes...');
+    const bufferTimesAry = [];
 
     try {
       const previousBufferSize = this.timeBuffered;
-      const bufferTimeStart = this.sourceBuffer.buffered.start(0);
-      const bufferTimeEnd = this.sourceBuffer.buffered.end(0);
-      const currentBufferSize = bufferTimeEnd - bufferTimeStart;
+      const bufferedRanges = this.sourceBuffer.buffered;
 
-      this.timeBuffered = currentBufferSize;
+      this.logger.warn('this.sourceBuffer.buffered length: ' + bufferedRanges.length);
 
+      for (let i = 0; i < bufferedRanges.length; i++) {        
+        this.logger.warn(`Range ${i}: ${bufferedRanges.start(i)} to ${bufferedRanges.end(i)} seconds`);
+        const bufferTimeStart = bufferedRanges.start(i);
+        const bufferTimeEnd = bufferedRanges.end(i);
+        const currentBufferSize = bufferTimeEnd - bufferTimeStart;
+        bufferTimesAry.push({
+          previousBufferSize,
+          currentBufferSize,
+          bufferTimeStart,
+          bufferTimeEnd,
+        });
+      }
+      const lastRange = bufferedRanges.length - 1;
+      this.timeBuffered = (bufferedRanges.end(lastRange) - bufferedRanges.start(lastRange));
       this.logger.silly('getBufferTimes finished successfully...');
 
-      return {
-        previousBufferSize,
-        currentBufferSize,
-        bufferTimeStart,
-        bufferTimeEnd,
-      };
+      return bufferTimesAry;
     }
     catch (error) {
       this.logger.info('Failed to getBufferTimes...');
@@ -281,72 +314,75 @@ export default class SourceBuffer extends EventEmitter {
    * called after EVERY UPDATE_END event!  Is that correct / necessary? Maybe
    * it should only be called every other time, or every 5th time...
    *
-   * @param {object|null} info
+   * @param {object[]|null} info
    *   optional, SourceBuffer time info
    * @param {boolean} shouldClear
    *   optional, defaults to false
    *   if true, will clear the entire SourceBuffer's internal buffer
    */
   trim (
-    info = this.getTimes(),
+    infoAry = this.getTimes(),
     shouldClear = false,
   ) {
     if (this.isDestroyComplete) {
       return;
     }
 
-    if (!info) {
-      this.logger.debug('Tried to trim buffer, failed to get buffer times...');
-      return;
-    }
-
-    this.logger.silly('trimBuffer...');
-
-    this.metric('sourceBuffer.lastKnownBufferSize', this.timeBuffered);
-
-    const shouldTrim = shouldClear || (this.timeBuffered > this.BUFFER_SIZE_LIMIT);
-
-    if (!shouldTrim) {
-      this.logger.debug('No need to trim');
-      return;
-    }
-
-    // @todo - should we wait for isReady here?
-    if (!this.isReady()) {
-      this.logger.info('Need to trim, but not ready...');
-      return;
-    }
-
-    try {
-      // @todo - Trimming is the biggest performance problem we have with this
-      // player. Can you figure out how to manage the memory usage without
-      // causing the streams to stutter?
-      this.metric('sourceBuffer.trim', this.BUFFER_TRUNCATE_VALUE);
-
-      if (shouldClear) {
-        this.logger.debug('Clearing buffer...');
-        this.sourceBuffer.remove(info.bufferTimeStart, Infinity);
-        this.logger.debug('Successfully cleared buffer...');
+    for (let infoIdx = 0; infoIdx < infoAry.length; infoIdx++) {
+      const info = infoAry[infoIdx];
+      if (!info) {
+        this.logger.debug('Tried to trim buffer, failed to get buffer times...');
+        return;
       }
-      else {
-        const trimEndTime = info.bufferTimeStart + this.BUFFER_TRUNCATE_VALUE;
+      this.logger.silly('trimBuffer...');
 
-        this.logger.debug('Trimming buffer...');
-        this.sourceBuffer.remove(info.bufferTimeStart, trimEndTime);
-        this.logger.debug('Successfully trimmed buffer...');
-      }
-    }
-    catch (error) {
-      if (error.constructor.name === 'DOMException') {
-        this.logger.info('Encountered DOMException while trying to trim buffer');
-        // @todo - every time the mseWrapper is destroyed, there is a
-        // sourceBuffer error.  No need to log that, but you should fix it
+      this.metric('sourceBuffer.lastKnownBufferSize', this.timeBuffered);
+
+      const shouldTrim = shouldClear || (this.timeBuffered > this.BUFFER_SIZE_LIMIT) ||
+       this.gapInBufferedRanges(infoIdx);
+
+      if (!shouldTrim) {
+        this.logger.debug('No need to trim');
         return;
       }
 
-      this.logger.debug('trimBuffer failure!');
+      // @todo - should we wait for isReady here?
+      if (!this.isReady()) {
+        this.logger.info('Need to trim, but not ready...');
+        return;
+      }
 
-      throw error;
+      try {
+        // @todo - Trimming is the biggest performance problem we have with this
+        // player. Can you figure out how to manage the memory usage without
+        // causing the streams to stutter?
+        this.metric('sourceBuffer.trim', this.BUFFER_TRUNCATE_VALUE);
+
+        if (shouldClear) {
+          this.logger.debug('Clearing buffer...');
+          this.sourceBuffer.remove(info.bufferTimeStart, Infinity);
+          this.logger.debug('Successfully cleared buffer...');
+        }
+        else {
+          const trimEndTime = info.bufferTimeStart + this.BUFFER_TRUNCATE_VALUE;
+
+          this.logger.debug('Trimming buffer...');
+          this.sourceBuffer.remove(info.bufferTimeStart, trimEndTime);
+          this.logger.debug('Successfully trimmed buffer...');
+        }
+      }
+      catch (error) {
+        if (error.constructor.name === 'DOMException') {
+          this.logger.info('Encountered DOMException while trying to trim buffer');
+          // @todo - every time the mseWrapper is destroyed, there is a
+          // sourceBuffer error.  No need to log that, but you should fix it
+          return;
+        }
+
+        this.logger.debug('trimBuffer failure!');
+
+        throw error;
+      }
     }
   }
 

--- a/src/js/iov/Player/MSE/__mocks__/MediaSourceMock.js
+++ b/src/js/iov/Player/MSE/__mocks__/MediaSourceMock.js
@@ -47,11 +47,14 @@ class MockSourceBuffer {
 }
 
 const MediaSource = jest.fn(() => ({
+  readyState: 'open',
+  duration: 5,
   // Mock the addSourceBuffer method to return an instance of your mocked SourceBuffer
   addSourceBuffer: jest.fn(() => new MockSourceBuffer()),
-
+  endOfStream: jest.fn(),
   // Mock any other methods or properties of MediaSource if necessary
   isTypeSupported: jest.fn(() => true),
+  isReady: jest.fn(() => true),
   addEventListener: jest.fn((event, listener) => {}),
 }));
 

--- a/src/js/iov/Player/MSE/__mocks__/MediaSourceMock.js
+++ b/src/js/iov/Player/MSE/__mocks__/MediaSourceMock.js
@@ -1,0 +1,58 @@
+// __mocks__/mediaSourceMock.js
+
+class MockTimeRanges {
+  constructor (ranges) {
+    this.ranges = ranges; // Array of [start, end] pairs
+  }
+
+  get length () {
+    return this.ranges.length;
+  }
+
+  start (index) {
+    if (index >= this.length) {
+      throw new DOMException('Index out of bounds');
+    }
+    return this.ranges[index][0];
+  }
+
+  end (index) {
+    if (index >= this.length) {
+      throw new DOMException('Index out of bounds');
+    }
+    return this.ranges[index][1];
+  }
+}
+
+class MockSourceBuffer {
+  constructor (mimeType) {
+    this.mimeType = mimeType;
+    this.updating = false;
+    this.buffered = new MockTimeRanges([
+      [
+        0,
+        0.034,
+      ], // First range: 0 to 0.034 seconds ( what we saw with bosch)
+      [
+        10,
+        15,
+      ], // Second range: 10 to 15 seconds (gap between 5-10 seconds)
+    ]);
+    this.appendBuffer = jest.fn();
+    this.remove = jest.fn();
+    this.addEventListener = jest.fn();
+    this.removeEventListener = jest.fn();
+    this.dispatchEvent = jest.fn();
+  }
+}
+
+const MediaSource = jest.fn(() => ({
+  // Mock the addSourceBuffer method to return an instance of your mocked SourceBuffer
+  addSourceBuffer: jest.fn(() => new MockSourceBuffer()),
+
+  // Mock any other methods or properties of MediaSource if necessary
+  isTypeSupported: jest.fn(() => true),
+  addEventListener: jest.fn((event, listener) => {}),
+}));
+
+module.exports = MediaSource;

--- a/src/js/iov/Player/MSE/__tests__/MSEWrapper.test.js
+++ b/src/js/iov/Player/MSE/__tests__/MSEWrapper.test.js
@@ -1,0 +1,26 @@
+import MSEWrapper from '../MSEWrapper';
+import MediaSource from 'MediaSource'; // Import the mocked MediaSource
+
+describe('MSEWrapper#onVideoSegmentShown()', () => {
+  let instance;
+
+  beforeEach(async () => {
+    global.window.MediaSource = MediaSource;
+    instance = MSEWrapper.factory('test');
+    instance.mediaSource = global.window.mediaSource;
+
+    await instance.initialize();
+    await instance.initializeSourceBuffer('video/mp4; codecs="avc1.42E01E"');
+  });
+
+  it('stream re-init', () => {
+    const emitSpy = jest.spyOn(instance, 'emit');
+
+    instance.sourceBuffer.emit('updateend');
+    instance.sourceBuffer.emit('updateend');
+    instance.sourceBuffer.emit('updateend');
+
+    expect(emitSpy).toHaveBeenCalledTimes(2);
+    expect(instance.emit).toHaveBeenCalledWith(MSEWrapper.events.STREAM_FROZEN);
+  });
+});

--- a/src/js/iov/Player/MSE/__tests__/MediaSourceMock.test.js
+++ b/src/js/iov/Player/MSE/__tests__/MediaSourceMock.test.js
@@ -1,0 +1,26 @@
+import MediaSource from 'MediaSource'; // Import the mocked MediaSource
+
+describe('MediaSource with SourceBuffer', () => {
+  let mediaSource;
+
+  beforeEach(() => {
+    // Create a new instance of the MediaSource mock
+    mediaSource = new MediaSource();
+  });
+
+  it('should interact with SourceBuffer and detect a gap between time ranges', () => {
+    // Add a SourceBuffer to the MediaSource
+    const sourceBuffer = mediaSource.addSourceBuffer();
+    const buffered = sourceBuffer.buffered;
+
+    // The time ranges should be non-contiguous, indicating a gap
+    expect(buffered).toHaveLength(2); // There should be two ranges
+    expect(buffered.start(0)).toBe(0); // The first range starts at 0
+    expect(buffered.end(0)).toBe(0.034); // The first range ends at 5
+    expect(buffered.start(1)).toBe(10); // The second range starts at 10 (gap between 5 and 10)
+    expect(buffered.end(1)).toBe(15); // The second range ends at 15
+
+    // Check that there is indeed a gap
+    expect(buffered.start(1) - buffered.end(0)).toBeGreaterThan(0); // There should be a gap between the ranges
+  });
+});

--- a/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
+++ b/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
@@ -77,3 +77,13 @@ describe('SourceBuffer.getTimes()', () => {
     expect(_.isEqual(times, knownTimes)).toBe(true);
   });
 });
+
+describe('SourceBuffer.trim()', () => {
+  it('trim if buffer exceeds size', () => {
+    jest.spyOn(SourceBuffer, 'getDefaultBufferSizeLimit').mockReturnValue(4);
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    sourceBuffer.trim();
+    jest.spyOn(sourceBuffer.sourceBuffer, 'remove');
+    expect(sourceBuffer.sourceBuffer.remove).toHaveBeenCalledWith(0, 2);
+  });
+});

--- a/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
+++ b/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
@@ -2,16 +2,77 @@ import MediaSource from 'MediaSource'; // Import the mocked MediaSource
 import SourceBuffer from '../SourceBuffer';
 import MediaSourceWrapper from '../MediaSourceWrapper';
 
+const _ = require('lodash');
+
 beforeEach(() => {
   global.window.MediaSource = MediaSource;
 });
 
-describe('SourceBuffer', () => {
-  it('should  detect a gap between time ranges', () => {
+describe('SourceBuffer.gapInBufferedRanges()', () => {
+  it('should detect a gap between time ranges', () => {
     // Add a SourceBuffer to the MediaSource
     const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
 
     // Check that there is indeed a gap
     expect(sourceBuffer.gapInBufferedRanges(0)).toBe(true);
   });
+
+  it('no gap with single time range', () => {
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    const buffered = sourceBuffer.sourceBuffer.buffered.ranges.pop();
+    expect(sourceBuffer.gapInBufferedRanges(0)).toBe(false);
+  });
+
+  it('no gap with multiple contiguous ranges', () => {
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    sourceBuffer.sourceBuffer.buffered.ranges.shift();
+    sourceBuffer.sourceBuffer.buffered.ranges.push([15,20]);
+    expect(sourceBuffer.gapInBufferedRanges(0)).toBe(false);
+  });
+
+  it('no time ranges present', () => {
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    sourceBuffer.sourceBuffer.buffered.ranges.length = 0;
+    expect(sourceBuffer.gapInBufferedRanges(0)).toBe(false);
+  });
+});
+
+
+describe('SourceBuffer.getTimes()', () => {
+  it('multiple time ranges with gap', () => {
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    let times = sourceBuffer.getTimes();
+
+    const knownTimes = [
+      {
+        previousBufferSize: null,
+        currentBufferSize: 0.034,
+        bufferTimeStart: 0,
+        bufferTimeEnd: 0.034
+      },
+      {
+        previousBufferSize: null,
+        currentBufferSize: 5,
+        bufferTimeStart: 10,
+        bufferTimeEnd: 15
+      }
+    ]
+    expect(_.isEqual(times, knownTimes)).toBe(true);
+  });
+
+  it('single time range', () => {
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+    sourceBuffer.sourceBuffer.buffered.ranges.shift();
+    const times = sourceBuffer.getTimes();
+    const knownTimes = [
+      {
+        previousBufferSize: null,
+        currentBufferSize: 5,
+        bufferTimeStart: 10,
+        bufferTimeEnd: 15
+      }
+    ]
+    expect(_.isEqual(times, knownTimes)).toBe(true);
+  });
+
 });

--- a/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
+++ b/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
@@ -19,14 +19,17 @@ describe('SourceBuffer.gapInBufferedRanges()', () => {
 
   it('no gap with single time range', () => {
     const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
-    const buffered = sourceBuffer.sourceBuffer.buffered.ranges.pop();
+    sourceBuffer.sourceBuffer.buffered.ranges.pop();
     expect(sourceBuffer.gapInBufferedRanges(0)).toBe(false);
   });
 
   it('no gap with multiple contiguous ranges', () => {
     const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
     sourceBuffer.sourceBuffer.buffered.ranges.shift();
-    sourceBuffer.sourceBuffer.buffered.ranges.push([15,20]);
+    sourceBuffer.sourceBuffer.buffered.ranges.push([
+      15,
+      20,
+    ]);
     expect(sourceBuffer.gapInBufferedRanges(0)).toBe(false);
   });
 
@@ -37,26 +40,25 @@ describe('SourceBuffer.gapInBufferedRanges()', () => {
   });
 });
 
-
 describe('SourceBuffer.getTimes()', () => {
   it('multiple time ranges with gap', () => {
     const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
-    let times = sourceBuffer.getTimes();
+    const times = sourceBuffer.getTimes();
 
     const knownTimes = [
       {
         previousBufferSize: null,
         currentBufferSize: 0.034,
         bufferTimeStart: 0,
-        bufferTimeEnd: 0.034
+        bufferTimeEnd: 0.034,
       },
       {
         previousBufferSize: null,
         currentBufferSize: 5,
         bufferTimeStart: 10,
-        bufferTimeEnd: 15
-      }
-    ]
+        bufferTimeEnd: 15,
+      },
+    ];
     expect(_.isEqual(times, knownTimes)).toBe(true);
   });
 
@@ -69,10 +71,9 @@ describe('SourceBuffer.getTimes()', () => {
         previousBufferSize: null,
         currentBufferSize: 5,
         bufferTimeStart: 10,
-        bufferTimeEnd: 15
-      }
-    ]
+        bufferTimeEnd: 15,
+      },
+    ];
     expect(_.isEqual(times, knownTimes)).toBe(true);
   });
-
 });

--- a/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
+++ b/src/js/iov/Player/MSE/__tests__/SourceBuffer.test.js
@@ -1,0 +1,17 @@
+import MediaSource from 'MediaSource'; // Import the mocked MediaSource
+import SourceBuffer from '../SourceBuffer';
+import MediaSourceWrapper from '../MediaSourceWrapper';
+
+beforeEach(() => {
+  global.window.MediaSource = MediaSource;
+});
+
+describe('SourceBuffer', () => {
+  it('should  detect a gap between time ranges', () => {
+    // Add a SourceBuffer to the MediaSource
+    const sourceBuffer = SourceBuffer.factory('test', 'video/mp4', new MediaSourceWrapper('test'));
+
+    // Check that there is indeed a gap
+    expect(sourceBuffer.gapInBufferedRanges(0)).toBe(true);
+  });
+});


### PR DESCRIPTION
Exclude previousTimeEnd from the conditional to determine if the buffer is frozen
Moved return out of re-init block so appendsSinceTimeEndUpdated isn't reset on each segment processed
Handle scenarios where there are time gaps and multiple time ranges exist in the sourcebuffer